### PR TITLE
Fix energy consumption calculation and update Tariff model

### DIFF
--- a/custom_components/combined_energy/models.py
+++ b/custom_components/combined_energy/models.py
@@ -345,7 +345,7 @@ class Tariff(BaseModel):
     source: str
     daily_fee: float = Field(alias="dailyFee")
     feed_in_cost: float = Field(alias="feedInCost")
-    as_at: datetime = Field(alias="asAt")
+    as_at: datetime | None = Field(default=None, alias="asAt")
     updated: datetime
 
     groups: list[TariffGroup]

--- a/custom_components/combined_energy/sensor.py
+++ b/custom_components/combined_energy/sensor.py
@@ -64,6 +64,7 @@ SENSOR_DESCRIPTIONS_GENERIC_CONSUMER = [
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         suggested_display_precision=2,
+        aggregation=Aggregation.SUM,
     ),
     CombinedEnergySensorDescription(
         key="energy_consumed_solar",


### PR DESCRIPTION
Correct the calculation of energy consumption for generic entities and make the `as_at` field optional in the Tariff model.